### PR TITLE
feat: Add source rectangle global offset support for native texture compatibility

### DIFF
--- a/TrinketTinker/Companions/Anim/TinkerAnimSprite.cs
+++ b/TrinketTinker/Companions/Anim/TinkerAnimSprite.cs
@@ -214,7 +214,14 @@ public sealed class TinkerAnimSprite
     /// <returns></returns>
     public Rectangle GetSourceRect(int frame)
     {
-        return new Rectangle(frame * Width % Texture.Width, frame * Width / Texture.Width * Height, Width, Height);
+        int x = frame * Width % Texture.Width;
+        int y = frame * Width / Texture.Width * Height;
+        
+        // 应用全局偏移
+        x += fullVd.SourceRectOffsetX;
+        y += fullVd.SourceRectOffsetY;
+        
+        return new Rectangle(x, y, Width, Height);
     }
 
     /// <summary>
@@ -406,6 +413,19 @@ public sealed class TinkerAnimSprite
         if (timer > interval)
         {
             currentFrame += step;
+            timer = 0f;
+            if (currentFrame == lastFrame)
+            {
+                UpdateSourceRect();
+                isReverse = !isReverse;
+                return isReverse ? TinkerAnimState.InProgress : TinkerAnimState.Complete;
+            }
+        }
+        UpdateSourceRect();
+        return TinkerAnimState.InProgress;
+    }
+}
+tFrame += step;
             timer = 0f;
             if (currentFrame == lastFrame)
             {

--- a/TrinketTinker/Models/VariantData.cs
+++ b/TrinketTinker/Models/VariantData.cs
@@ -138,6 +138,12 @@ public sealed class VariantData : IVariantData
     /// <summary>If set, add a light with given radius. Note that the light is only visible to local player.</summary>
     public LightSourceData? LightSource { get; set; } = null;
 
+    /// <summary>全局X轴偏移，用于调整所有帧的SourceRect.X坐标</summary>
+    public int SourceRectOffsetX { get; set; } = 0;
+
+    /// <summary>全局Y轴偏移，用于调整所有帧的SourceRect.Y坐标</summary>
+    public int SourceRectOffsetY { get; set; } = 0;
+
     /// <summary>Sprite index of the item icon.</summary>
     public int TrinketSpriteIndex { get; set; } = -1;
 


### PR DESCRIPTION
# Problem Description
This commit addresses compatibility issues with native game textures that don't conform to the author's default specifications. The original implementation lacked configuration parameters to handle texture coordinate discrepancies, leading to improper sprite rendering.


# Main Changes
- Added `SourceRectOffsetX` and `SourceRectOffsetY` properties to `VariantData` model
- Implemented offset application in `TinkerAnimSprite.GetSourceRect()` method
- Fixed animation state handling for reverse animations


# Technical Implementation
The `GetSourceRect(int frame)` method now includes offset calculation:
```csharp
// Apply global offset  
x += fullVd.SourceRectOffsetX;  
y += fullVd.SourceRectOffsetY;  
```


# Impact Scope
- Affects all animations using `TinkerAnimSprite`
- Provides flexible source rectangle positioning for native textures
- Maintains backward compatibility (default offset values are 0)

This feature enables proper rendering of game-native textures that don't follow standard specifications, ensuring visual consistency across different texture sources.