### PR TITLE
Add multi-target monster selection using Closest/Random target modes

### DIFF
--- a/TrinketTinker/Effects/Abilities/HitscanAbility.cs
+++ b/TrinketTinker/Effects/Abilities/HitscanAbility.cs
@@ -1,3 +1,4 @@
+using StardewValley;
 using StardewValley.Monsters;
 using TrinketTinker.Effects.Support;
 using TrinketTinker.Models;

--- a/TrinketTinker/Effects/Abilities/HitscanAbility.cs
+++ b/TrinketTinker/Effects/Abilities/HitscanAbility.cs
@@ -1,8 +1,8 @@
-using StardewValley;
 using StardewValley.Monsters;
 using TrinketTinker.Effects.Support;
 using TrinketTinker.Models;
 using TrinketTinker.Models.AbilityArgs;
+using TrinketTinker.Wheels;
 
 namespace TrinketTinker.Effects.Abilities;
 
@@ -21,19 +21,26 @@ public sealed class HitscanAbility(TrinketTinkerEffect effect, AbilityData data,
     /// <inheritdoc/>
     protected override bool ApplyEffect(ProcEventArgs proc)
     {
-        Monster? target =
-            proc.Monster
-            ?? Utility.findClosestMonsterWithinRange(
-                proc.LocationOrCurrent,
-                e.CompanionPosOff ?? proc.Farmer.Position,
-                args.Range,
-                ignoreUntargetables: true,
-                match: FilterMonster
-            );
-        if (target == null)
+        List<Monster> targets = Places.SelectMatchingMonsters(
+            proc.LocationOrCurrent,
+            e.CompanionPosOff ?? proc.Farmer.Position,
+            args.Range,
+            args.MaxTargetCount,
+            args.TargetMode,
+            proc.Monster,
+            FilterMonster
+        );
+
+        if (targets.Count == 0)
             return false;
-        proc.Monster = target;
-        args.DamageMonster(proc.GSQContext, target, false);
+
+        proc.Monster = targets[0];
+
+        foreach (Monster target in targets)
+        {
+            args.DamageMonster(proc.GSQContext, target, false);
+        }
+
         return base.ApplyEffect(proc);
     }
 }

--- a/TrinketTinker/Effects/Abilities/ProjectileAbility.cs
+++ b/TrinketTinker/Effects/Abilities/ProjectileAbility.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using StardewValley;
 using StardewValley.Monsters;
 using TrinketTinker.Effects.Support;
 using TrinketTinker.Models;

--- a/TrinketTinker/Effects/Abilities/ProjectileAbility.cs
+++ b/TrinketTinker/Effects/Abilities/ProjectileAbility.cs
@@ -1,9 +1,9 @@
 using Microsoft.Xna.Framework;
-using StardewValley;
 using StardewValley.Monsters;
 using TrinketTinker.Effects.Support;
 using TrinketTinker.Models;
 using TrinketTinker.Models.AbilityArgs;
+using TrinketTinker.Wheels;
 
 namespace TrinketTinker.Effects.Abilities;
 
@@ -22,18 +22,27 @@ public sealed class ProjectileAbility(TrinketTinkerEffect effect, AbilityData da
     protected override bool ApplyEffect(ProcEventArgs proc)
     {
         Vector2 sourcePosition = e.CompanionPosition ?? proc.Farmer.Position;
-        Monster? target =
-            proc.Monster
-            ?? Utility.findClosestMonsterWithinRange(
-                proc.LocationOrCurrent,
-                sourcePosition,
-                args.Range,
-                ignoreUntargetables: true,
-                match: FilterMonster
-            );
-        if (target == null)
+
+        List<Monster> targets = Places.SelectMatchingMonsters(
+            proc.LocationOrCurrent,
+            sourcePosition,
+            args.Range,
+            args.MaxTargetCount,
+            args.TargetMode,
+            proc.Monster,
+            FilterMonster
+        );
+
+        if (targets.Count == 0)
             return false;
-        proc.LocationOrCurrent.projectiles.Add(new TinkerProjectile(args, proc, target, sourcePosition));
+
+        proc.Monster = targets[0];
+
+        foreach (Monster target in targets)
+        {
+            proc.LocationOrCurrent.projectiles.Add(new TinkerProjectile(args, proc, target, sourcePosition));
+        }
+
         return base.ApplyEffect(proc);
     }
 }

--- a/TrinketTinker/Models/AbilityArgs/DamageArgs.cs
+++ b/TrinketTinker/Models/AbilityArgs/DamageArgs.cs
@@ -7,6 +7,12 @@ using TrinketTinker.Wheels;
 
 namespace TrinketTinker.Models.AbilityArgs;
 
+public enum TargetSelectionMode
+{
+    Closest,
+    Random,
+}
+
 /// <summary>Damage to monster argument</summary>
 public class DamageArgs : IArgs
 {
@@ -21,6 +27,12 @@ public class DamageArgs : IArgs
 
     /// <summary>Restrict monster picks to facing direction only</summary>
     public bool FacingDirectionOnly { get; set; } = false;
+
+    /// <summary>Maximum number of monsters to target.</summary>
+    public int MaxTargetCount { get; set; } = 1;
+
+    /// <summary>How targets should be selected from valid monsters in range.</summary>
+    public TargetSelectionMode TargetMode { get; set; } = TargetSelectionMode.Closest;
 
     /// <summary>Knockback modifier</summary>
     public float Knockback { get; set; } = 0f;
@@ -79,6 +91,8 @@ public class DamageArgs : IArgs
     public bool Validate()
     {
         if (Range < 1)
+            return false;
+        if (MaxTargetCount < 1)
             return false;
         if (Min > Max)
         {

--- a/TrinketTinker/Wheels/Places.cs
+++ b/TrinketTinker/Wheels/Places.cs
@@ -2,7 +2,10 @@ using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Extensions;
 using StardewValley.GameData.Locations;
+using StardewValley.Monsters;
 using StardewValley.TerrainFeatures;
+using TrinketTinker.Models.AbilityArgs;
+using StardewModdingAPI;
 
 namespace TrinketTinker.Wheels;
 
@@ -12,6 +15,37 @@ internal static class Places
     /// <summary>Custom</summary>
     public const string Field_DisableTrinketAbilities = $"{ModEntry.ModId}/disableAbilities";
     public const string Field_DisableTrinketCompanions = $"{ModEntry.ModId}/disableCompanions";
+
+        private const bool DebugTargetSelection = true;
+
+    private static void LogTargetSelection(string message)
+    {
+        if (DebugTargetSelection)
+            ModEntry.Log(message, LogLevel.Info);
+    }
+
+    private static string DescribeMonster(Monster monster, Vector2 originPoint)
+    {
+        float distance = Vector2.Distance(originPoint, monster.getStandingPosition());
+        return $"{monster.Name}@{distance:0.0}";
+    }
+
+    private static string DescribeMonsterList(List<Monster> monsters, Vector2 originPoint)
+    {
+        if (monsters.Count == 0)
+            return "[]";
+
+        System.Text.StringBuilder sb = new();
+        sb.Append('[');
+        for (int i = 0; i < monsters.Count; i++)
+        {
+            if (i > 0)
+                sb.Append(", ");
+            sb.Append(DescribeMonster(monsters[i], originPoint));
+        }
+        sb.Append(']');
+        return sb.ToString();
+    }
 
     /// <summary>Find closest matching farm animal within range</summary>
     /// <param name="location"></param>
@@ -74,6 +108,122 @@ internal static class Places
             }
         }
         return result;
+    }
+
+    /// <summary>Get all matching monsters within range.</summary>
+    /// <param name="location"></param>
+    /// <param name="originPoint"></param>
+    /// <param name="range"></param>
+    /// <param name="match"></param>
+    /// <returns></returns>
+    public static List<Monster> MatchingMonsters(
+        GameLocation location,
+        Vector2 originPoint,
+        int range,
+        Func<Monster, bool>? match = null
+    )
+    {
+        List<Monster> result = new();
+        foreach (NPC character in location.characters)
+        {
+            if (character is not Monster monster || monster.IsInvisible)
+                continue;
+
+            float distance = Vector2.Distance(originPoint, monster.getStandingPosition());
+            if (distance > range)
+                continue;
+
+            if (match == null || match(monster))
+                result.Add(monster);
+        }
+        return result;
+    }
+
+    /// <summary>Select matching monsters within range according to target mode and max target count.</summary>
+    /// <param name="location"></param>
+    /// <param name="originPoint"></param>
+    /// <param name="range"></param>
+    /// <param name="maxTargetCount"></param>
+    /// <param name="targetMode"></param>
+    /// <param name="guaranteedTarget"></param>
+    /// <param name="match"></param>
+    /// <returns></returns>
+        public static List<Monster> SelectMatchingMonsters(
+        GameLocation location,
+        Vector2 originPoint,
+        int range,
+        int maxTargetCount,
+        TargetSelectionMode targetMode,
+        Monster? guaranteedTarget = null,
+        Func<Monster, bool>? match = null
+    )
+    {
+        List<Monster> candidates = MatchingMonsters(location, originPoint, range, match);
+        List<Monster> originalCandidates = new(candidates);
+        List<Monster> result = new();
+
+        bool guaranteedValid = false;
+        if (guaranteedTarget != null)
+        {
+            float guaranteedDistance = Vector2.Distance(originPoint, guaranteedTarget.getStandingPosition());
+            guaranteedValid =
+                !guaranteedTarget.IsInvisible
+                && guaranteedDistance <= range
+                && (match == null || match(guaranteedTarget));
+
+            if (guaranteedValid)
+            {
+                result.Add(guaranteedTarget);
+                candidates.RemoveAll(monster => ReferenceEquals(monster, guaranteedTarget));
+            }
+        }
+
+        int remainingCount = Math.Max(0, maxTargetCount - result.Count);
+
+        switch (targetMode)
+        {
+            case TargetSelectionMode.Closest:
+                candidates.Sort((a, b) =>
+                    Vector2.Distance(originPoint, a.getStandingPosition())
+                        .CompareTo(Vector2.Distance(originPoint, b.getStandingPosition()))
+                );
+                break;
+
+            case TargetSelectionMode.Random:
+                ShuffleInPlace(Game1.random, candidates);
+                break;
+        }
+
+        if (remainingCount > 0)
+            result.AddRange(candidates.Take(remainingCount));
+
+        string guaranteedText = guaranteedTarget == null
+            ? "null"
+            : DescribeMonster(guaranteedTarget, originPoint);
+
+        LogTargetSelection(
+            $"[TargetSelection] Mode={targetMode}, Max={maxTargetCount}, Range={range}, " +
+            $"Guaranteed={guaranteedText}, GuaranteedValid={guaranteedValid}, " +
+            $"Pool={DescribeMonsterList(originalCandidates, originPoint)}, " +
+            $"RemainingPool={DescribeMonsterList(candidates, originPoint)}, " +
+            $"Result={DescribeMonsterList(result, originPoint)}"
+        );
+
+        return result;
+    }
+
+    /// <summary>Shuffle a list in place using Fisher-Yates shuffle.</summary>
+    /// <param name="rand"></param>
+    /// <param name="listToShuffle"></param>
+    private static void ShuffleInPlace<T>(Random rand, List<T> listToShuffle)
+    {
+        int n = listToShuffle.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = rand.Next(n + 1);
+            (listToShuffle[n], listToShuffle[k]) = (listToShuffle[k], listToShuffle[n]);
+        }
     }
 
     /// <summary>Find nearest placed object within range.</summary>


### PR DESCRIPTION
## Summary

This PR adds a feature so trinkets can target more than one monster.

It introduces:
- `MaxTargetCount`
- `TargetMode` (`Closest` / `Random`)

What it currently does in a nutshell:
- Gathers all valid monsters in range
- Preserves a valid `proc.Monster` first when present
- Fills remaining slots up to `MaxTargetCount`
  - `Closest` = sort by distance and take first N
  - `Random` = shuffle and take first N

## Files changed
- `DamageArgs.cs`
- `Places.cs`
- `HitscanAbility.cs`
- `ProjectileAbility.cs`

## Notes
- `TargetMode` defaults to `Closest`
- `MaxTargetCount` defaults to `1`
- Anchor logic was intentionally left unchanged for now
- Debug logging was left in `Places.cs` for review/testing

## Testing
- Hitscan: Closest/Random with `MaxTargetCount` 1 and 3 all worked as expected
- Projectile showed the same target-selection behaviour as Hitscan
- Synced abilities correctly preserve a valid guaranteed target before filling extra slots

Opened as a draft for review before merge.